### PR TITLE
Add lower cpu clocks to sys-clk-OC and add some info to readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Uncompress the kip to make it work with config editor: `hactool -t kip1 Atmosphe
 
 - CPU OC (up to ~ 2.1 GHz, depending on your CPU bin) is available mainly for emulation, but it does NOT work out of the box.
 
+- GPU OC (Higher than 921) Does not result in preformance improvements on Ersita, instead just producing more heat and drawing more power without any benefits. 
 
 ## Acknowledgement
 

--- a/Source/Atmosphere/stratosphere/loader/source/oc/ldr_oc_suite.cpp
+++ b/Source/Atmosphere/stratosphere/loader/source/oc/ldr_oc_suite.cpp
@@ -943,7 +943,7 @@ namespace ams::ldr::oc {
         constexpr u32 CpuVoltLimit3   = 1227;
         constexpr u32 MemVoltHOS      = 1125'000;
         constexpr u32 MemClkOSLimit   = 1600'000;
-        constexpr u32 MemClkPllmLimit = 1866'000'000;
+        constexpr u32 MemClkPllmLimit = 1996'000'000;
 
         constexpr cpu_freq_cvb_table_t NewCpuTables[] = {
          // OldCpuTables

--- a/Source/sys-clk-OC/README.md
+++ b/Source/sys-clk-OC/README.md
@@ -25,6 +25,8 @@ Switch sysmodule allowing you to set cpu/gpu clocks according to the running app
 * 816
 * 714
 * 612
+* 510
+* 408
 
 ### GPU clocks
 

--- a/Source/sys-clk-OC/common/src/clock_table.c
+++ b/Source/sys-clk-OC/common/src/clock_table.c
@@ -30,6 +30,8 @@ uint32_t sysclk_g_freq_table_mem_hz[] = {
 };
 
 uint32_t sysclk_g_freq_table_cpu_hz[] = {
+    408000000,
+    510000000,
     612000000,
     714000000,
     816000000,


### PR DESCRIPTION
Basically add lower clocks as some games can use go down to 408mhz (Like Sonic Mania). Also add some info in the readme about 921+ erista oc.